### PR TITLE
Reboot on Raspbian only if needed and wait

### DIFF
--- a/roles/raspbian/handlers/main.yml
+++ b/roles/raspbian/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: Rebooting on Raspbian 
+  reboot:

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -7,8 +7,6 @@
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
   when: ( ansible_facts.architecture is search "arm" )
+  notify:
+    - Rebooting on Raspbian
 
-- name: Rebooting on Raspbian 
-  shell: reboot now
-  ignore_errors: true
-  when: ( ansible_facts.architecture is search "arm" )


### PR DESCRIPTION
Thanks so much for your playbook!
I've been tinkering with it this afternoon to set a k3s cluster on my raspberries, but found an issue, namely the fact that it was rebooting all the rasps when running the raspbian role, but then it was immediately failing because they were unreachable.

In this changeset:
  - "Reboot in Raspbian" will only happen if /boot/cmdline.txt was changed, which adds idempotency
  - "Reboot in Raspbian" will wait for the system to be back online

Happy to include any change you consider necessary