### PR TITLE
Rename group to avoid hyphens. Fixes itwars/k3s-ansible#4

### DIFF
--- a/hosts.ini
+++ b/hosts.ini
@@ -6,6 +6,6 @@
 192.168.1.10
 192.168.1.37
 
-[k3s-cluster:children]
+[k3s_cluster:children]
 master
 node

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: k3s-cluster
+- hosts: k3s_cluster
   gather_facts: yes
   become: yes
   roles:


### PR DESCRIPTION
At some point Ansible dropped support for hyphens in inventory groups, so I guess it's ok to replace them by underscores.